### PR TITLE
Enable generating drop reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ kube-system   int-host-reporter-x48ps                    1/1     Running   0    
 ## Verify drop reports
 
 The drop reasons specified by the Calico eBPF datapath are eBPF-specific (e.g. fail to adjust room during encapsulation). 
-Thus, it is not straightforward to verify drop reports. The common case for packet drops is a malformed IPv4 packet (e.g. ihl != 5).
-To verify drop reports we can simply generate malformed UDP packets. Note that destination IPv4 address and UDP port 
+Thus, it is not straightforward to verify drop reports. The common case for packet drops is IP TTL < 0.
+To verify drop reports we can simply generate UDP packets with IPv4 TTL = 0. Note that destination IPv4 address and UDP port 
 must point to the K8s NodePort service.
 
 ```bash

--- a/pkg/packet/int_report.go
+++ b/pkg/packet/int_report.go
@@ -31,14 +31,22 @@ const (
 const (
 	// Common drop reasons
 	DropReasonUnknown = 0
+	DropReasonIPVersionInvalid = 25
 	DropReasonIPTTLZero = 26
+	DropReasonIPIHLInvalid = 30
+	DropReasonIPInvalidChecksum = 31
 	DropReasonRoutingMiss = 29
 	DropReasonPortVLANMappingMiss = 55
 	DropReasonTrafficManager = 71
 	DropReasonACLDeny = 80
 	DropReasonBridginMiss = 89
 
-	// TODO: Calico-specific drop reasons
+	// Calico-specific drop reasons
+	DropReasonEncapFail = 180
+	DropReasonDecapFail = 181
+	DropReasonChecksumFail = 182
+	DropReasonIPOptions = 183
+	DropReasonUnauthSource = 184
 )
 
 var (
@@ -188,8 +196,22 @@ func dropReasonConvertFromDatapathToINT(datapathCode uint8) uint8 {
 	case 0:
 		// unknown reason has the same code.
 		return datapathCode
+	case 207:
+		return DropReasonChecksumFail
+	case 239:
+		return DropReasonEncapFail
+	case 223:
+		return DropReasonDecapFail
+	case 235:
+		return DropReasonIPOptions
+	case 236:
+		return DropReasonIPIHLInvalid
+	case 237:
+		return DropReasonUnauthSource
 	case 240:
 		return DropReasonIPTTLZero
+	case 241:
+		return DropReasonACLDeny
 	default:
 		log.WithFields(log.Fields{
 			"code": datapathCode,


### PR DESCRIPTION
TODO:
- [x] extend Calico eBPF datapath to generate drop reports for IP TTL ZERO
- [x] apply watchlist also for the drop reports
- [x] implement mapping between Calico drop reasons and INT drop reasons 
- [x] test on the PDP dev pod