### PR TITLE
Add BMD_MODE compile flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=builder /go/src/app .
 COPY --from=builder /go/bin/int-host-reporter /usr/local/bin
 
 RUN apt update
-RUN apt install -y iproute2 clang libbpf-dev llvm
+RUN apt install -y iproute2 clang-10 libbpf-dev llvm-10
 RUN ./scripts/compile-bpf.sh
 
 CMD ["int-host-reporter"]

--- a/bpf/flags.h
+++ b/bpf/flags.h
@@ -1,9 +1,13 @@
 // Copyright 2021-present Open Networking Foundation
 // SPDX-License-Identifier: GPL-2.0-only
 
-/* Bridged metadata mode */
+/* Bridged metadata modes */
+/* BMD_MODE_SKB_CB: use skb->cb to pass random packet identifier */
 #define BMD_MODE_SKB_CB 0
+/* BMD_MODE_SKB_PTR: use address of skb descriptor as packet identifier */
 #define BMD_MODE_SKB_PTR 1
+/* BMD_MODE_FLOW_HASH: use flow hash retrieved by bpf_get_hash_recalc() as packet identifier. */
+#define BMD_MODE_FLOW_HASH 2
 
 #ifndef BMD_MODE
 #define BMD_MODE BMD_MODE_SKB_CB

--- a/bpf/flags.h
+++ b/bpf/flags.h
@@ -1,0 +1,11 @@
+// Copyright 2021-present Open Networking Foundation
+// SPDX-License-Identifier: GPL-2.0-only
+
+/* Bridged metadata mode */
+#define BMD_MODE_SKB_CB 0
+#define BMD_MODE_SKB_PTR 1
+
+#ifndef BMD_MODE
+#define BMD_MODE BMD_MODE_SKB_CB
+#endif
+

--- a/pkg/dataplane/dataplane_interface.go
+++ b/pkg/dataplane/dataplane_interface.go
@@ -97,21 +97,7 @@ func (d *DataPlaneInterface) Init() error {
 	layers.RegisterUDPPortLayerType(8472, layers.LayerTypeVXLAN)
 
 	commonPath := common.DefaultMapRoot + "/" + common.DefaultMapPrefix
-	path := commonPath + "/" + common.INTWatchlistProtoSrcAddrMap
-	watchlistMap, err := ebpf.LoadPinnedMap(path, nil)
-	if err != nil {
-		return err
-	}
-	d.watchlistMapProtoSrcAddr = watchlistMap
-
-	path = commonPath + "/" + common.INTWatchlistDstAddrMap
-	watchlistMap, err = ebpf.LoadPinnedMap(path, nil)
-	if err != nil {
-		return err
-	}
-	d.watchlistMapDstAddr = watchlistMap
-
-	path = commonPath + "/" + common.INTSharedMap
+	path := commonPath + "/" + common.INTSharedMap
 	sharedMap, err := ebpf.LoadPinnedMap(path, nil)
 	if err != nil {
 		return err

--- a/scripts/compile-bpf.sh
+++ b/scripts/compile-bpf.sh
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Flags:
-# -DBMD_MODE=<BMD_MODE_SKB_PTR | BMD_MODE_SKB_CB>, default=BMD_MODE_SKB_CB
+# -DBMD_MODE=<BMD_MODE_SKB_PTR | BMD_MODE_SKB_CB | BMD_MODE_SKB_FLOW_HASH>, default=BMD_MODE_SKB_CB
 clang-10 -O2 -emit-llvm -g -c bpf/int-datapath.c -o - | llc-10 -march=bpf -filetype=obj -o /opt/out.o

--- a/scripts/compile-bpf.sh
+++ b/scripts/compile-bpf.sh
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Flags:
-# -DBMD_MODE=<BMD_MODE_SKB_PTR | BMD_MODE_SKB_CB | BMD_MODE_SKB_FLOW_HASH>, default=BMD_MODE_SKB_CB
+# -DBMD_MODE=<BMD_MODE_SKB_PTR | BMD_MODE_SKB_CB | BMD_MODE_FLOW_HASH>, default=BMD_MODE_SKB_CB
 clang-10 -O2 -emit-llvm -g -c bpf/int-datapath.c -o - | llc-10 -march=bpf -filetype=obj -o /opt/out.o

--- a/scripts/compile-bpf.sh
+++ b/scripts/compile-bpf.sh
@@ -1,4 +1,6 @@
 # Copyright 2021-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-clang -O2 -emit-llvm -g -c bpf/int-datapath.c -o - | llc -march=bpf -filetype=obj -o /opt/out.o
+# Flags:
+# -DBMD_MODE=<BMD_MODE_SKB_PTR | BMD_MODE_SKB_CB>, default=BMD_MODE_SKB_CB
+clang-10 -O2 -emit-llvm -g -c bpf/int-datapath.c -o - | llc-10 -march=bpf -filetype=obj -o /opt/out.o


### PR DESCRIPTION
Using `uintptr_t` format of `skb` as a unique packet identifier is prohibited by older kernels (e.g. 5.4 or 5.8) - BPF verifier rejects such programs. Thus, it becomes impossible to deploy Host-INT on old OS's. 

This PR implements a new way to generate & pass unique packet identifier between ingress and egress. The `BMD_MODE_SKB_CB` uses `bpf_get_prandom_u32()` to generate a pseudo-random identifier and the most significant byte of `skb->cb` (`skb->cb[4]`) is used to carry this identifier between ingress and egress. I've observed that other bytes are being cleared by iptables. 